### PR TITLE
[Windows10] Build Check Function added for Docker Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # setup-tools
-This Repository is for providing ready-made commands / scripts to automate the setup process of a development environment. Each setup is separated by OS/Distro.
+Ready-made commands/executables for automatic Development Environment Setup. Each setup is separated by OS/Distro.
 
 ## Distros Currently Supported and tools provided
 * Ubuntu Bionic Beaver (18.04 LTS)
@@ -8,8 +8,8 @@ This Repository is for providing ready-made commands / scripts to automate the s
 	* zsh (Includes Powerline Fonts)
 	* Oh-my-zsh
 
-* Windows 10
-	* Docker Desktop
+* Windows 10 Home & Windows 10 Pro
+	* Docker Desktop / Docker Toolbox
 	* Git
 	* VSCode
 	* MYSQL Workbench

--- a/Windows_10/02_install_docker_desktop(Run as Admin).bat
+++ b/Windows_10/02_install_docker_desktop(Run as Admin).bat
@@ -2,9 +2,11 @@
 echo "Checking Docker Compatibility with current OS"
 setlocal
 set "winEdition="
+REM Gets the String for the OS Version, e.g 'Microsoft Windows 10 Home Single Language'
 for /f "tokens=2 delims==" %%G in ('wmic os get Caption /value') do (
     if not defined winEdition set winEdition=%%G
 )
+rem Checks if the OS version is Home or Pro
 echo %winEdition% | find "Windows 10 Pro" > nul
     if errorlevel 1 (
         echo "Windows 10 Home Detected"
@@ -16,6 +18,7 @@ echo %winEdition% | find "Windows 10 Pro" > nul
         goto BUILD_CHECK
     )
 :BUILD_CHECK
+    rem Checks the Build Version, as there are supported build versions for Windows Home and Windows Pro
     echo "Checking if OS Build is Compatible with Docker Desktop"
     for /f "tokens=4-7 delims=[.] " %%i in ('ver') do @(if %%i==Version (set build=%%l) else (set build=%%k))
     if %edition% == "Home" (

--- a/Windows_10/02_install_docker_desktop(Run as Admin).bat
+++ b/Windows_10/02_install_docker_desktop(Run as Admin).bat
@@ -1,1 +1,41 @@
-choco install docker-desktop
+@echo off
+echo "Checking Docker Compatibility with current OS"
+setlocal
+set "winEdition="
+for /f "tokens=2 delims==" %%G in ('wmic os get Caption /value') do (
+    if not defined winEdition set winEdition=%%G
+)
+echo %winEdition% | find "Windows 10 Pro" > nul
+    if errorlevel 1 (
+        echo "Windows 10 Home Detected"
+        set edition="Home"
+        goto BUILD_CHECK
+    ) else (
+        echo "Windows 10 Pro Detected"
+        set edition="Pro"
+        goto BUILD_CHECK
+    )
+:BUILD_CHECK
+    echo "Checking if OS Build is Compatible with Docker Desktop"
+    for /f "tokens=4-7 delims=[.] " %%i in ('ver') do @(if %%i==Version (set build=%%l) else (set build=%%k))
+    if %edition% == "Home" (
+        if %build% geq 19018 (
+            goto DOCKER_DESKTOP
+        ) else (
+            goto DOCKER_TOOLBOX
+        )
+    ) else (
+        if %build% geq 15063 (
+            goto DOCKER_DESKTOP
+        ) else (
+            goto DOCKER_TOOLBOX
+        )
+    )
+:DOCKER_DESKTOP
+    echo "Build valid, installing Docker Desktop"
+    choco install docker-desktop
+    goto :EOF
+:DOCKER_TOOLBOX
+    echo "Build invalid, installing Docker CLI"
+    choco install docker-toolbox
+    goto :EOF


### PR DESCRIPTION
Fixes: #3 

Problem:
The past executable was only installing Docker Desktop which does not work for certain versions of Windows like Windows Home.

Solution:
Added functions that will check current version of Windows if its Home or Pro, then check if the build number is supported by Docker Desktop. If the Build version is valid, it will install Docker Desktop, if not then it will install Docker Toolbox instead.